### PR TITLE
Api gateway now uses the image from dojot/kong-docker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "apigw/plugins/pep-kong"]
+	path = apigw/plugins/pep-kong
+	url = https://github.com/dojot/pep-kong

--- a/apigw/kong.conf
+++ b/apigw/kong.conf
@@ -1,8 +1,0 @@
-
-custom_plugins = pepkong         # Comma-separated list of additional plugins
-                                 # this node should load.
-                                 # Use this property to load custom plugins
-                                 # that are not bundled with Kong.
-                                 # Plugins will be loaded from the
-                                 # `kong.plugins.{name}.*` namespace.
-

--- a/apigw/kong.conf
+++ b/apigw/kong.conf
@@ -1,0 +1,8 @@
+
+custom_plugins = pepkong         # Comma-separated list of additional plugins
+                                 # this node should load.
+                                 # Use this property to load custom plugins
+                                 # that are not bundled with Kong.
+                                 # Plugins will be loaded from the
+                                 # `kong.plugins.{name}.*` namespace.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
           - kong-db
 
   apigw:
-    image: dojot/pep-kong:latest
+    image: dojot/kong:latest
     restart: always
     depends_on:
       - postgres
@@ -128,6 +128,9 @@ services:
       KONG_DATABASE: "postgres"
       KONG_CASSANDRA_CONTACT_POINTS: "cassandra"
       KONG_PG_HOST: "postgres"
+    volumes:    
+      - ./apigw/kong.conf:/etc/kong/kong.conf
+      - ./apigw/plugins/pep-kong:/plugins/pep-kong
     networks:
       default:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,6 @@ services:
       KONG_CASSANDRA_CONTACT_POINTS: "cassandra"
       KONG_PG_HOST: "postgres"
     volumes:    
-      - ./apigw/kong.conf:/etc/kong/kong.conf
       - ./apigw/plugins/pep-kong:/plugins/pep-kong
     networks:
       default:


### PR DESCRIPTION
Docker-compose description was changed for the apigw to use the image from dojot/kong-docker. The new image is not plugin-dependent so the pep-kong plugin is now included in a volume and was imported as a git submodule.
The commit sugests the new kong image to be located on the docker cloud on dojot/kong.
Pull request related to issue dojot/docker-compose#10