### PR TITLE
Adds alarm model for docker-monitor service

### DIFF
--- a/alarms/dojot.docker.ContainerError.xml
+++ b/alarms/dojot.docker.ContainerError.xml
@@ -7,5 +7,6 @@
   </primary-subject>
   <additional-data>
     <additional-field type="alphanumeric">exitCode</additional-field>
+    <additional-field type="alphanumeric">imageId</additional-field>
   </additional-data>
 </alarm-metamodel>

--- a/alarms/dojot.docker.ContainerError.xml
+++ b/alarms/dojot.docker.ContainerError.xml
@@ -1,0 +1,11 @@
+<alarm-metamodel>
+  <domain>ContainerError</domain>
+  <namespace>dojot.docker</namespace>
+  <primary-subject>
+    <primary-field type="alphanumeric">container</primary-field>
+    <primary-field type="alphanumeric">image</primary-field>
+  </primary-subject>
+  <additional-data>
+    <additional-field type="alphanumeric">exitCode</additional-field>
+  </additional-data>
+</alarm-metamodel>


### PR DESCRIPTION
It defines the alarm model for docker-monitor service to be loaded by the dojot Alarm Manager 

This is connected to dojot/dojot#228