### PR TITLE
fix: fixing flowbroker-context-manager image name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:Z
 
   flowbroker-context-manager:
-    image: dojot/context-manager:latest
+    image: dojot/flowbroker-context-manager:latest
     restart: always
     environment:
       ZOOKEEPER_HOST: zookeeper


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes the context-manager container image name


* **What is the current behavior?** (You can also link to an open issue here)
Users can't pull its image, as it doesn't exist as it is.


* **What is the new behavior (if this is a feature change)?**
Users should be able to pull its image.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/dojot#627

* **Other information**:
