### PR TITLE
adding kong user creation in postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,14 +160,24 @@ services:
   postgres:
     image: "postgres:9.4-alpine"
     restart: always
-    environment:
-      POSTGRES_USER: "kong"
-      POSTGRES_DB: "kong"
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  postgres-users:
+    image: "postgres:9.4-alpine"
+    restart: on-failure
+    command: >
+      bash -c "createuser kong -d -h postgres -U postgres && createdb kong -U kong -h postgres"
+    depends_on:
+      postgres:
+        condition: service_healthy
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds a temporary container to create a user in postgres (as its image is not what we expected no more). 


* **What is the current behavior?** (You can also link to an open issue here)
Now if the environment variable POSTGRES_USER is set, then no default user 'postgres' is created and the only user is the one set in this variable. If not set, then the default 'postgres' user is created. 


* **What is the new behavior (if this is a feature change)?**
The user 'kong' is created in postgres after it starts.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No

* **Other information**:
