### PR TITLE
Adding Dockerfile for Kong with installed dependencies

### DIFF
--- a/Dockerfile-apigw.static
+++ b/Dockerfile-apigw.static
@@ -1,0 +1,10 @@
+FROM dojot/kong:v0.2.1
+
+RUN yum -y update && yum -y install git && mkdir /plugins
+
+RUN cd /plugins; git clone https://github.com/dojot/ma-kong-plugin.git mutualauthentication
+RUN cd /plugins; git clone https://github.com/dojot/pep-kong pep-kong
+
+RUN \
+  luarocks install uuid 0.2-1; \
+  luarocks install json4lua 0.9.30-1;


### PR DESCRIPTION
This Dockerfile will generate an image with all dependencies
pre-installed. That way it can be used in scenarios without
internet access.

* **Please check if the PR fulfills these requirements**
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds a new Dockerfile that generates a Kong (API gateway) image with all installed dependencies.


* **What is the current behavior?** (You can also link to an open issue here)
Kong will try to install Lua dependencies the first time it runs.


* **What is the new behavior (if this is a feature change)?**
No internet access is needed (all Kong dependencies are already installed).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
dojot/docker-compose#81

* **Other information**:
