### PR TITLE
Change data-broker-redis image version to a fix one

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
         max-size: 100m
 
   data-broker-redis:
-    image: redis:alpine
+    image: redis:5.0.5-alpine3.10
     restart: always
     logging:
       driver: json-file


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Data Broker Redis image version is alpine, which is not a fixed one, it is the latest with alpine. The latest version breaks the Travis CI build in data-broker PRs, making it impossible to merge them.


* **What is the new behavior (if this is a feature change)?**
Fix Data Broker Redis image version in 5.0.5-alpine3.10


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I've tested the application and no problems were found.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
https://github.com/dojot/dojot/issues/1233

* **Other information**:
