### PR TITLE
removing pep kong from repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "apigw/plugins/pep-kong"]
-	path = apigw/plugins/pep-kong
-	url = https://github.com/dojot/pep-kong

--- a/Dockerfile-apigw.static
+++ b/Dockerfile-apigw.static
@@ -1,9 +1,0 @@
-FROM dojot/kong:v0.2.1
-
-RUN yum -y update && yum -y install git && mkdir /plugins
-
-RUN cd /plugins; git clone https://github.com/dojot/pep-kong pep-kong
-
-RUN \
-  luarocks install uuid 0.2-1; \
-  luarocks install json4lua 0.9.30-1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,8 +272,6 @@ services:
     environment:
       KONG_DATABASE: "postgres"
       KONG_PG_HOST: "postgres"
-    volumes:
-      - ./apigw/plugins/pep-kong:/plugins/pep-kong:Z
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Removed PEP Kong plugin submodule
- Removed volume from kong service


* **What is the current behavior?** (You can also link to an open issue here)
PEP Kong is a git submodule from this repository and used in kong volume


* **What is the new behavior (if this is a feature change)?**
PEP kong is in the same kong repository and the kong image is built with the plugin, so the submodule and de volume from this repository were removed


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
The user does not need to use "git submodule update --init --recursive" anymore

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
Yes, this PR is connected to dojot/dojot#1337 and dojot/dojot#1338

* **Other information**:
This change will only work with the kong image changed by PR dojot/kong/pull/14