### PR TITLE
Inclusion of new iotagent-mqtt and its peripherals

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,39 +43,6 @@ services:
       - mongodb-volume:/data/db
       - mongodb-cfg-volume:/data/configdb
 
-  mosca-redis:
-    image: dojot/redis:5.0.5-alpine3.10
-    restart: always
-    volumes:
-      - mosca-redis-volume:/data
-    logging:
-      driver: json-file
-      options:
-        max-size: 100m
-
-  iotagent-mqtt:
-    image: dojot/iotagent-mosca:development
-    depends_on:
-      - mosca-redis
-      - kafka
-      - data-broker
-      - auth
-      - ejbca
-    ports:
-      - 1883:1883
-      - 8883:8883
-    restart: always
-    environment:
-      DOJOT_MANAGEMENT_USER: 'iotagent-mqtt'
-      KAFKA_GROUP_ID: 'iotagent-mqtt-group'
-      ALLOW_UNSECURED_MODE: 'true'
-      LOG_LEVEL: 'info'
-      MOSCA_TLS_DNS_LIST: 'localhost'
-    logging:
-      driver: json-file
-      options:
-        max-size: 100m
-
   gui:
     image: dojot/gui:development
     restart: always
@@ -441,19 +408,6 @@ services:
       options:
         max-size: 100m
 
-  ejbca:
-    image: dojot/ejbca-rest:development
-    environment:
-      DOJOT_MANAGEMENT_USER: 'ejbca'
-      KAFKA_GROUP_ID: 'ejbca-group'
-    restart: always
-    volumes:
-      - old-ejbca-volume:/data
-    logging:
-      driver: json-file
-      options:
-        max-size: 100m
-
   x509-identity-mgmt:
     image: dojot/x509-identity-mgmt:development
     depends_on:
@@ -495,6 +449,69 @@ services:
     restart: always
     volumes:
       - kafka-ws-redis-volume:/data
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  iotagent-mqtt:
+    image: dojot/vernemq-dojot:development
+    command: ["/bin/bash", "-c", "echo $$VERNEMQ_CONF | base64 -d > /etc/vernemq/vernemq.conf; echo $$VM_ARGS | base64 -d > /etc/vernemq/vm.args; /vernemq/vmq_dojot.sh"]
+    depends_on:
+      - x509-identity-mgmt
+    ports:
+      - 1883:1883
+      - 8883:8883
+    environment:
+      HOSTNAME: iotagent-mqtt
+      INTERNAL_DNS: iotagent-mqtt
+      EXTERNAL_SERVER_IP: "127.0.0.1"
+      EXTERNAL_SERVER_HOSTNAME: localhost
+      VERNEMQ_CONF: YWNjZXB0X2V1bGEgPSB5ZXMKbWV0YWRhdGFfcGx1Z2luID0gdm1xX3N3YwpwbHVnaW5zLnZtcV9wYXNzd2QgPSBvZmYKcGx1Z2lucy52bXFfYWNsID0gb2ZmCnBsdWdpbnMuZG9qb3RfZGlzY29ubmVjdF9wbHVnaW4ucGF0aCA9IC92ZXJuZW1xL2Rvam90X2Rpc2Nvbm5lY3RfcGx1Z2luL2RlZmF1bHQKcGx1Z2lucy5kb2pvdF9kaXNjb25uZWN0X3BsdWdpbiA9IG9uCnBsdWdpbnMuZG9qb3RfZGlzY29ubmVjdF9wbHVnaW4ucHJpb3JpdHkgPSAyCnBsdWdpbnMuZG9qb3RfYWNsX3BsdWdpbi5wYXRoID0gL3Zlcm5lbXEvZG9qb3RfYWNsX3BsdWdpbi9kZWZhdWx0CnBsdWdpbnMuZG9qb3RfYWNsX3BsdWdpbiA9IG9uCnBsdWdpbnMuZG9qb3RfYWNsX3BsdWdpbi5wcmlvcml0eSA9IDIKbGV2ZWxkYi5tYXhpbXVtX21lbW9yeS5wZXJjZW50ID0gMjAKbG9nLmNvbnNvbGUgPSBjb25zb2xlCmxpc3RlbmVyLm1heF9jb25uZWN0aW9ucyA9IDIwMDAwMApsaXN0ZW5lci5ucl9vZl9hY2NlcHRvcnMgPSAxMDAKbWF4X2luZmxpZ2h0X21lc3NhZ2VzID0gMjAKbWF4X29ubGluZV9tZXNzYWdlcyA9IDEwMDAwCmxpc3RlbmVyLnNzbC5kZWZhdWx0ID0gMC4wLjAuMDo4ODgzCmxpc3RlbmVyLnNzbC5kZWZhdWx0LmNhZmlsZSA9ICAvdmVybmVtcS9jZXJ0L2NhLmNydApsaXN0ZW5lci5zc2wuZGVmYXVsdC5jZXJ0ZmlsZSA9IC92ZXJuZW1xL2NlcnQvaW90YWdlbnQtbXF0dC5jcnQKbGlzdGVuZXIuc3NsLmRlZmF1bHQua2V5ZmlsZSA9IC92ZXJuZW1xL2NlcnQvaW90YWdlbnQtbXF0dC5rZXkKbGlzdGVuZXIuc3NsLmRlZmF1bHQuY3JsZmlsZSA9ICAvdmVybmVtcS9jZXJ0L2NhLmNybApsaXN0ZW5lci5zc2wuZGVmYXVsdC51c2VfaWRlbnRpdHlfYXNfdXNlcm5hbWUgPSBvbgpsaXN0ZW5lci5zc2wuZGVmYXVsdC5yZXF1aXJlX2NlcnRpZmljYXRlID0gb24=
+      VM_ARGS: K1AgMjU2MDAwCi1lbnYgRVJMX01BWF9FVFNfVEFCTEVTIDI1NjAwMAotZW52IEVSTF9DUkFTSF9EVU1QIC92ZXJuZW1xL2xvZy9lcmxfY3Jhc2guZHVtcAotZW52IEVSTF9GVUxMU1dFRVBfQUZURVIgMAotZW52IEVSTF9NQVhfUE9SVFMgMjYyMTQ0CitBIDY0Ci1zZXRjb29raWUgdm1xCi1uYW1lIHZtcUBpb3RhZ2VudC1tcXR0LmRvam90LmlvdAorSyB0cnVlCitXIHcKLXNtcCBlbmFibGU=
+    restart: always
+    hostname: iotagent-mqtt
+    domainname: dojot.iot
+    volumes:
+      - iotagent-mqtt-volume:/vernemq/data
+      - iotagent-mqtt-volume:/vernemq/log
+      - iotagent-mqtt-volume:/vernemq/etc
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  v2k-bridge:
+    image: dojot/v2k-bridge:development
+    depends_on:
+      - iotagent-mqtt
+      - kafka
+      - x509-identity-mgmt
+      - data-broker
+    environment:
+      V2K_APP_HOSTNAME: v2k-bridge
+      V2K_MQTT_SERVER_ADDRESS: iotagent-mqtt
+      V2K_MQTT_SERVER_PORT: 8883
+      V2K_KAFKA_METADATA_BROKER_LIST: kafka:9092
+    restart: always
+    logging:
+      driver: json-file
+      options:
+        max-size: 100m
+
+  k2v-bridge:
+    image: dojot/k2v-bridge:development
+    depends_on:
+      - iotagent-mqtt
+      - kafka
+      - x509-identity-mgmt
+      - data-broker
+    environment:
+      K2V_APP_HOSTNAME: k2v-bridge
+      K2V_MQTT_SERVER_ADDRESS: iotagent-mqtt
+      K2V_MQTT_SERVER_PORT: 8883
+      K2V_KAFKA_METADATA_BROKER_LIST: kafka:9092
+    restart: always
     logging:
       driver: json-file
       options:
@@ -556,18 +573,17 @@ volumes:
   postgres-volume:
   mongodb-volume:
   mongodb-cfg-volume:
-  old-ejbca-volume:
   minio-volume:
   rabbitmq-volume:
   zookeeper-volume:
   kafka-volume:
+  iotagent-mqtt-volume:
   auth-redis-volume:
   flowbroker-volume:
   flowbroker-redis-volume:
   data-broker-redis-volume:
   device-manager-redis-volume:
   kafka-ws-redis-volume:
-  mosca-redis-volume:
 
 networks:
   flowbroker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -454,7 +454,7 @@ services:
         max-size: 100m
 
   iotagent-mqtt:
-    image: dojot/vernemq-dojot:development
+    image: dojot/vernemq-dojot:v0.5.0-alpha.3
     command: ["/bin/bash", "-c", "echo $$VERNEMQ_CONF | base64 -d > /etc/vernemq/vernemq.conf; echo $$VM_ARGS | base64 -d > /etc/vernemq/vm.args; /vernemq/vmq_dojot.sh"]
     depends_on:
       - x509-identity-mgmt
@@ -481,7 +481,7 @@ services:
         max-size: 100m
 
   v2k-bridge:
-    image: dojot/v2k-bridge:development
+    image: dojot/v2k-bridge:v0.5.0-alpha.3
     depends_on:
       - iotagent-mqtt
       - kafka
@@ -499,7 +499,7 @@ services:
         max-size: 100m
 
   k2v-bridge:
-    image: dojot/k2v-bridge:development
+    image: dojot/k2v-bridge:v0.5.0-alpha.3
     depends_on:
       - iotagent-mqtt
       - kafka

--- a/kong/kong.config.sh
+++ b/kong/kong.config.sh
@@ -170,5 +170,12 @@ addAuthToEndpoint "x509-identity-mgmt"
 
 # service: kafka-ws
 createEndpoint "kafka-ws" "http://kafka-ws:8080/"  '"/kafka-ws"' "false"
+
+curl -sS -X PATCH \
+    --url ${kong}/services/kafka-ws \
+    --data "read_timeout=300000" \
+    --data "write_timeout=300000" \
+    --data "connect_timeout=300000"
+
 createEndpoint "kafka-ws-ticket" "http://kafka-ws:8080/"  '"/kafka-ws/v[0-9]+/ticket"' "false"
 addAuthToEndpoint "kafka-ws-ticket"

--- a/kong/kong.config.sh
+++ b/kong/kong.config.sh
@@ -171,6 +171,9 @@ addAuthToEndpoint "x509-identity-mgmt"
 # service: kafka-ws
 createEndpoint "kafka-ws" "http://kafka-ws:8080/"  '"/kafka-ws"' "false"
 
+echo ""
+echo ""
+echo "- add timeout to kafka-ws"
 curl -sS -X PATCH \
     --url ${kong}/services/kafka-ws \
     --data "read_timeout=300000" \


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Change in MqTT functionality

* **What is the current behavior?** (You can also link to an open issue here)

Uses the IoT Agent _Mosca_

* **What is the new behavior (if this is a feature change)?**

Uses the IoT Agent _VerneMQ_

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

_Before:_
`mosquitto_pub -m '{"band":4}' -t '/admin/4e8898/attrs' -u admin -i admin -h 127.0.0.1 -p 8883 --cafile ca.pem --cert cert.pem --key private.key`

_After:_
`mosquitto_pub -m '{"band":4}' -t 'admin:4e8898/attrs' -h 127.0.0.1 -p 8883 --cafile ca.pem --cert cert.pem --key private.key`

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

[dojot/dojot/1535](https://app.zenhub.com/workspaces/dojot-ws-5ca7620c263982676581b05d/issues/dojot/dojot/1535)

* **Other information**:

So that `mosquitto_pub` can be used on another computer to publish mqtt messages on the platform, it is necessary to set the variable `EXTERNAL_SERVER_IP` and `EXTERNAL_SERVER_HOSTNAME` (of the service _iotagent-mqtt_) with the IP or hostname of the platform _host computer_.
      
The `vernemq.conf` and `vm.args` files are passed to the VerneMQ container (_iotagent-mqtt_) through the environment variables `VERNEMQ_CONF` and `VM_ARGS` respectively. The value of these variables is the content of these files in _Base64_.