### PR TITLE
fix zookeeper volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -365,9 +365,9 @@ services:
     image: dojot/zookeeper:3.4
     restart: always
     volumes:
-      - zookeeper-volume:/datalog
-      - zookeeper-volume:/logs
       - zookeeper-volume:/data
+      - zookeeper-logs-volume:/logs
+      - zookeeper-datalog-volume:/datalog
     logging:
       driver: json-file
       options:
@@ -437,6 +437,8 @@ volumes:
   minio-volume:
   rabbitmq-volume:
   zookeeper-volume:
+  zookeeper-logs-volume:
+  zookeeper-datalog-volume:
   kafka-volume:
   auth-redis-volume:
   flowbroker-volume:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The same volume is being used at 3 different mount points in the zookeeper service

* **What is the new behavior (if this is a feature change)?**

Each mount point must have its respective volume in the zookeeper's service

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

dojot/dojot#1586

* **Other information**:

It is a complement to PR:
https://github.com/dojot/docker-compose/pull/163