### PR TITLE
fix kafka hostname (branch "development")

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -429,6 +429,7 @@ services:
     depends_on:
       - zookeeper
     restart: always
+    hostname: "kafka"
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_HOST_NAME: kafka


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When the kafka container is destroyed and a new container is created, the host name changes and this causes the V2K to not be able to take mqtt messages from verne to kafka.

* **What is the new behavior (if this is a feature change)?**

When the kafka container is destroyed and a new container is created, the host name must be the same.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

This problem started to occur after the volumes were mapped on the docker-compose:
dojot/dojot#1586

* **Other information**:
