### PR TITLE
Replace Auth to Keycloak

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 COMPOSE_PROJECT_NAME=dojot
 FLOWBROKER_NETWORK=flowbroker
 DATA_BROKER_SERVICE_PORT=80
+DOJOT_MODULE_PYTHON=../../dojot-module-python/dojot/module
+DOJOT_MODULE_NODEJS=../../dojot-module-nodejs

--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ FLOWBROKER_NETWORK=flowbroker
 DATA_BROKER_SERVICE_PORT=80
 DOJOT_MODULE_PYTHON=../../dojot-module-python/dojot/module
 DOJOT_MODULE_NODEJS=../../dojot-module-nodejs
+KEYCLOAK_HEALTHCHECK_URL=http://localhost:8080/auth/realms/admin/.well-known/openid-configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -326,7 +326,7 @@ services:
         max-size: 100m
 
   keycloak:
-    image: local/keycloak:development
+    image: dojot/keycloak:feature-keycloak-10.0.1
     healthcheck:
       test: ["CMD-SHELL", "curl ${KEYCLOAK_HEALTHCHECK_URL}"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -328,7 +328,7 @@ services:
   keycloak:
     image: local/keycloak:development
     healthcheck:
-      test: ["CMD-SHELL", "curl http://localhost:8080/auth/realms/admin/.well-known/openid-configuration"]
+      test: ["CMD-SHELL", "curl ${KEYCLOAK_HEALTHCHECK_URL}"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -335,17 +335,15 @@ services:
     depends_on:
       - postgres
       - kafka
-    ports:
-      - "8080:8080"
     environment:
       DB_VENDOR: POSTGRES
       DB_ADDR: postgres
       DB_DATABASE: keycloak
       DB_USER: keycloak
       DB_PASSWORD: keycloak
-      KEYCLOAK_USER: admin
-      KEYCLOAK_PASSWORD: admin
-      KEYCLOAK_FRONTEND_URL: http://keycloak:8080/auth
+      KEYCLOAK_USER: ${KEYCLOAK_USER:?KEYCLOAK_USER required}
+      KEYCLOAK_PASSWORD: ${KEYCLOAK_PASSWORD:?KEYCLOAK_PASSWORD required}
+      PROXY_ADDRESS_FORWARDING: 'true'
 
   flowbroker:
     image: dojot/flowbroker:development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,17 @@ services:
 
   persister:
     image: dojot/persister:development
+    volumes: 
+      - ${DOJOT_MODULE_PYTHON}:/usr/src/venv/lib/python3.6/site-packages/dojot.module-0.0.1a5-py3.6.egg/dojot/module
     restart: always
     depends_on:
       - mongodb
-      - auth
+      - keycloak
       - kafka
       - data-broker
+    depends_on:
+      keycloak:
+        condition: service_healthy
     environment:
       FALCON_SETTINGS_MODULE: 'history.settings.docker'
       DOJOT_MANAGEMENT_USER: 'persister'
@@ -69,11 +74,16 @@ services:
 
   data-broker:
     image: dojot/data-broker:development
+    volumes: 
+    - ${DOJOT_MODULE_NODEJS}:/opt/data-broker/node_modules/@dojot/dojot-module
     restart: always
     depends_on:
       - kafka
       - data-broker-redis
-      - auth
+      - keycloak
+    depends_on:
+      keycloak:
+        condition: service_healthy
     environment:
       DOJOT_MANAGEMENT_USER: 'data-broker'
       KAFKA_GROUP_ID: 'data-broker-group'
@@ -101,12 +111,15 @@ services:
 # iot-agent lwm2m
 ################
   iotagent-lwm2m:
-    image: dojot/iotagent-leshan:development
+    image: local/iotagent-leshan:development
     depends_on:
       - kafka
       - data-broker
-      - auth
+      - keycloak
       - image-manager
+    depends_on:
+      keycloak:
+        condition: service_healthy
     environment:
       DOJOT_MANAGEMENT_USER: 'iotagent-lwm2m'
       KAFKA_GROUP_ID: "iotagent-lwm2m-group"
@@ -253,7 +266,7 @@ services:
         max-size: 100m
 
   apigw:
-    image: dojot/kong:development
+    image: local/kong:development
     depends_on:
       postgres:
         condition: service_healthy
@@ -312,38 +325,27 @@ services:
       options:
         max-size: 100m
 
-  auth:
-    image: dojot/auth:development
-    restart: always
+  keycloak:
+    image: local/keycloak:development
+    healthcheck:
+      test: ["CMD-SHELL", "curl http://localhost:8080/auth/realms/admin/.well-known/openid-configuration"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
     depends_on:
-      - apigw
       - postgres
-      - auth-redis
+      - kafka
+    ports:
+      - "8080:8080"
     environment:
-      AUTH_DB_HOST: "postgres"
-      AUTH_DB_USER: "auth"
-      AUTH_DB_PWD:  "auth"
-      AUTH_KONG_URL: "http://apigw:8001"
-      AUTH_CACHE_HOST: "auth-redis"
-      # This is used to select the type of cache to be used.
-      # Allowed values are "redis" or "nocache"
-      AUTH_CACHE_NAME: "redis"
-      DOJOT_MANAGEMENT_USER: 'auth'
-      KAFKA_GROUP_ID: 'auth-group'
-    logging:
-      driver: json-file
-      options:
-        max-size: 100m
-
-  auth-redis:
-    image: dojot/redis:5.0.5-alpine3.10
-    restart: always
-    volumes:
-      - auth-redis-volume:/data
-    logging:
-      driver: json-file
-      options:
-        max-size: 100m
+      DB_VENDOR: POSTGRES
+      DB_ADDR: postgres
+      DB_DATABASE: keycloak
+      DB_USER: keycloak
+      DB_PASSWORD: keycloak
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin
+      KEYCLOAK_FRONTEND_URL: http://keycloak:8080/auth
 
   flowbroker:
     image: dojot/flowbroker:development
@@ -358,15 +360,19 @@ services:
       - rabbitmq
       - kafka
       - mongodb
-      - auth
+      - keycloak
       - flowbroker-context-manager
       - flowbroker-redis
+    depends_on: 
+      keycloak:
+        condition: service_healthy
     networks:
       - default
       - flowbroker
     volumes:
       - flowbroker-volume:/data
       - /var/run/docker.sock:/var/run/docker.sock:Z
+      - ${DOJOT_MODULE_NODEJS}:/opt/flowbroker/orchestrator/node_modules/@dojot/dojot-module
     logging:
       driver: json-file
       options:
@@ -643,11 +649,16 @@ services:
 
   cron:
     image: dojot/cron:development
+    volumes: 
+    - ${DOJOT_MODULE_NODEJS}:/opt/cron/node_modules/@dojot/dojot-module
     depends_on:
       - kafka
       - data-broker
-      - auth
+      - keycloak
       - mongodb
+    depends_on: 
+      keycloak:
+        condition: service_healthy
     restart: always
     logging:
       driver: json-file
@@ -720,7 +731,6 @@ volumes:
   iotagent-mqtt-volume:
   iotagent-mqtt-log-volume:
   iotagent-mqtt-etc-volume:
-  auth-redis-volume:
   flowbroker-volume:
   flowbroker-redis-volume:
   data-broker-redis-volume:

--- a/kong/kong.config.sh
+++ b/kong/kong.config.sh
@@ -21,7 +21,7 @@ echo "- addAuthToEndpoint: ServiceName=${1}"
 
 curl -X POST ${kong}/services/"${1}"/plugins \
   --data "name=jwt-keycloak" \
-  --data "config.allowed_iss=http://keycloak:8080/auth/realms/admin"
+  --data "config.allowed_iss=http://localhost:8000/auth/realms/admin"
 
 curl  -sS  -X POST \
 --url ${kong}/services/"${1}"/plugins/ \
@@ -78,6 +78,10 @@ echo "- createEndpoint: ServiceName=${1} Url=${2} PathS=${3} StripPath=${4}"
 createService "${1}" "${2}"
 createRoute "${1}" "${1}_route" "${3}" "${4}"
 }
+
+# service: auth
+
+createEndpoint "auth-service" "http://keycloak:8080/auth"  '"/auth"' "true"
 
 # service: gui
 

--- a/local_env.MD
+++ b/local_env.MD
@@ -1,10 +1,3 @@
-Build keycloak image:
-
-```bash
-git clone https://github.com/dojot/dojot.git && cd dojot && git checkout feature-keycloak-10.0.1
-docker build -t local/keycloak:development ./docker
-```
-
 Build kong image:
 
 ```bash

--- a/local_env.MD
+++ b/local_env.MD
@@ -26,7 +26,6 @@ iotagent-lwm2m:
     <dependency>
         <groupId>com.github.dojot</groupId>
         <artifactId>dojot-module-java</artifactId>
-        <version>6e9cebd903a00e65ac7a9fac00333d769e2fb7a9</version>
         <version>keycloak_10.0.1-SNAPSHOT</version>
     </dependency>
 ```

--- a/local_env.MD
+++ b/local_env.MD
@@ -1,0 +1,32 @@
+Build keycloak image:
+
+```bash
+git clone https://github.com/dojot/dojot.git && cd dojot && git checkout feature-keycloak-10.0.1
+docker build -t local/keycloak:development ./docker
+```
+
+Build kong image:
+
+```bash
+git clone https://github.com/dojot/kong.git && cd kong && git checkout keycloak_10.0.1
+docker build -t local/kong:development .
+```
+
+To avoid that some services try list tenants from Auth (old access control system) is necessary use volumes until new library version be available on repository.
+
+```bash
+DOJOT_MODULE_PYTHON=<dojot-module-python directory>
+DOJOT_MODULE_NODEJS=<dojot-module-nodejs directory>
+```
+
+iotagent-lwm2m:
+
+```xml
+<!-- replace dojot-module-java version -->
+    <dependency>
+        <groupId>com.github.dojot</groupId>
+        <artifactId>dojot-module-java</artifactId>
+        <version>6e9cebd903a00e65ac7a9fac00333d769e2fb7a9</version>
+        <version>keycloak_10.0.1-SNAPSHOT</version>
+    </dependency>
+```

--- a/postgres/init-db.sh
+++ b/postgres/init-db.sh
@@ -18,4 +18,6 @@ psql -v ON_ERROR_STOP=1 --dbname postgres --username  postgres  <<-EOSQL
     CREATE database imgm;
     CREATE USER imgm WITH UNENCRYPTED PASSWORD 'imgm';
     ALTER ROLE imgm WITH CREATEDB;
+    CREATE database keycloak;
+    CREATE USER keycloak WITH UNENCRYPTED PASSWORD 'keycloak';
 EOSQL


### PR DESCRIPTION
This PR replace Auth to Keycloak, some workarounds was needed because the services persister, data-broker, flowbroker, cron and leshan doesn't use the new dojot-module library version yet, for more detail read the file  "local_env.MD"