### PR TITLE
[Fix] Readme and data source prometheus

### DIFF
--- a/monitoring/PROMETHEUS.md
+++ b/monitoring/PROMETHEUS.md
@@ -134,6 +134,16 @@ If the file is empty, paste the following:
 
 If the file is not empty, add these two keys, making sure the resulting file is a valid JSON. Be careful that all lines must end with a comma "," except the last line.
 
+In order for the changes to be applied it is necessary to restart the docker daemon and the docker itself.
+
+```
+sudo systemctl daemon-reload
+```
+
+```
+sudo systemctl restart docker
+```
+
 Since we are running Prometheus on localhost, in case we try to use the docker as localhost as well, Prometheus could understand that the metrics are inside the service itself (Prometheus) and then, could try to access port ``9323`` inside the Promethues container. To prevent this from happening we should use the default IP **172.17.0.1** of the **bridge** docker ``docker0``.
 
 Before running make sure that the ``docker0`` IP is really the default (172.17.0.1) with the following command:

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -3,7 +3,7 @@ apiVersion: 1
 datasources:
  - name: Prometheus
    type: prometheus
-   access: direct
-   url: http://localhost:9090
+   access: default
+   url: http://prometheus:9090
    isDefault: true
    editable: true


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

Currently, for the developer or a client to want to view the panels via ssh, it is necessary to open two tunnels, one for grafana and one for prometheus

* **What is the new behavior (if this is a feature change)?**

Now the data source of prometheus in grafana is directed to the server, so just open a single tunnel to grafana.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Now the user will not need to open two ssh tunnels, but only one, simplifying the use of the service.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**:
