### PR TITLE
[Dev] Removing externalization of ports 

### DIFF
--- a/monitoring/docker-compose-monitoring.yml
+++ b/monitoring/docker-compose-monitoring.yml
@@ -7,8 +7,6 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-volume:/prometheus
-    ports:
-      - 9090:9090
     depends_on:
       - cadvisor
     networks:
@@ -17,8 +15,6 @@ services:
   cadvisor:
     image: google/cadvisor:v0.32.0
     container_name: cadvisor
-    ports:
-      - 8082:8080
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:rw
@@ -29,15 +25,11 @@ services:
   redis:
     image: redis:6.2.5
     container_name: redis
-    ports:
-      - 6379:6379
   node_exporter:
     image: prom/node-exporter:v1.2.2
     container_name: node_exporter
     command:
       - "--path.rootfs=/host"
-    ports:
-      - 9100:9100
     restart: unless-stopped
     volumes:
       - "/:/host:ro,rslave"
@@ -45,15 +37,11 @@ services:
     image: danielqsj/kafka-exporter:v1.4.1
     container_name: kafka_exporter
     command: --kafka.server=kafka:9092
-    ports:
-      - 9308:9308
     networks:
       - dojot-monitoring
   mongodb_exporter:
     image: bitnami/mongodb-exporter:0.11.2
     container_name: mongodb_exporter
-    ports:
-      - 8880:9216
     environment:
       - MONGODB_URI=mongodb://mongodb:27017
     networks:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature


* **What is the current behavior?** (You can also link to an open issue here)

Currently, in the declaration of services in docker-compose their respective ports are being externalized.

* **What is the new behavior (if this is a feature change)?**

Now, only grafana will have the port externalized, after all, there is no need to externalize the other services.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)

No

* **Other information**:
