### PR TITLE
Remove basic-auth deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -841,7 +841,6 @@ services:
       - http-agent-cert-sidecar
       - device-manager
       - certificate-acl
-      - basic-auth
     ports:
       - 8080:3000
     environment:
@@ -1123,27 +1122,6 @@ services:
   #   ports:
   #     - 5050:80
 # GUI to postgres - END
-
-  basic-auth:
-    image: dojot/device-basic-authentication:${DOJOT_VERSION}
-    restart: always
-    depends_on:
-      - kafka
-      - data-broker
-      - mongodb
-      - auth
-      - device-manager
-    ports:
-      - 3110:3000
-    environment:
-      BASIC_AUTH_LOG_CONSOLE_LEVEL: 'info'
-      BASIC_AUTH_LOG_VERBOSE: "true"
-      BASIC_AUTH_PRODUCER_METADATA_BROKER_LIST: kafka:9092
-    logging:
-      driver: json-file
-      options:
-        max-size: 20m
-        max-file: '5'
 
 volumes:
   ejbca-volume:


### PR DESCRIPTION
Foi decidido que o serviço `basic-auth` não entrará na versão v0.8.0, então por isso ele está sendo removido do docker-compose.