### PR TITLE
Fixa uma versão antiga do pgadmin compatível com o pg 9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1332,7 +1332,7 @@ services:
 # GUI to postgres - BEGIN
 # GUI will be available at http://${DOJOT_DOMAIN_NAME}:5050
   pgadmin:
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:6.9
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@pgadmin.com
       PGADMIN_DEFAULT_PASSWORD: admin


### PR DESCRIPTION
Atualmente, o pgadmin sem tag está buscando a imagem da versão 6.15, que gera warnings pra cada operação quando conectado à nossa versão do postgres.
Na propria orientação do warning, indicam utilizar a versão 6.9 - que é o que esse PR inclui
Futuramente, quando fizermos upgrade na versão do postgres, também poderemos evoluir a versão do pgadmin